### PR TITLE
Add libprotobuf-c

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM bitnami/postgresql:latest
+FROM bitnami/postgresql:10
 USER root
 
 RUN mkdir -p /var/lib/apt/lists/partial \
-   && install_packages wget gcc make build-essential libxml2-dev libgeos-dev libproj-dev libgdal-dev postgresql-contrib
+   && install_packages wget gcc make build-essential libxml2-dev libgeos-dev libproj-dev libgdal-dev postgresql-contrib libprotobuf-c1 libprotobuf-c-dev protobuf-c-compiler
 
 ENV POSTGIS_VERSION 2.5.2
 


### PR DESCRIPTION
I'm getting this error when trying to use this image with https://github.com/urbica/martin:
```
34.66.134.165 postgres@gis_test=# WITH bounds AS (SELECT ST_MakeEnvelope(5009377.085000001, 0, 10018754.170000002, -5009377.085, 3857) as mercator, ST_MakeEnvelope(5009377.085000001, 0, 10018754.170000002, -5009377.085, 3857)
as original)
[more] - > SELECT ST_AsMVT(tile, 'public.v_portal2_veth_buildings_g', 4096, 'geom' ) FROM (
[more] ( >   SELECT
[more] ( >     ST_AsMVTGeom(wkb_geometry, bounds.mercator, 4096, 64, true) AS geom , "ogc_fid","id"
[more] ( >   FROM public.v_portal2_veth_buildings_g, bounds
[more] ( >   WHERE wkb_geometry && bounds.original
[more] ( > ) AS tile WHERE geom IS NOT NULL;
ERROR:  XX000: Missing libprotobuf-c
LOCATION:  pgis_asmvt_finalfn, lwgeom_out_mvt.c:125
Time: 159.513 ms
34.66.134.165 postgres@gis_test=#
```
This PR adds the missing dependency.